### PR TITLE
Copyright formatting?

### DIFF
--- a/src/TocAddin/version.json
+++ b/src/TocAddin/version.json
@@ -5,6 +5,6 @@
 	"description": "This addin generates a table of contents from the headings in your markdown file. The table of contents is placed at the location of the cursor.",
 	"version": "1.0",
 	"minVersion": "1.4.5",
-	"author": "© Daniel Vaughan",
+	"author": "© Daniel Vaughan http://danielvaughan.org",
 	"updated": "2017-08-04T12:00:00Z"
 }


### PR DESCRIPTION
Looks like there's something funky with the encoding of this file - the copyright is not showing up properly when being read in the addin-registry. Can you make sure the file is saved with UTF-8 encoding to properly handle the extended chars? Same for the Auto Number addin (which showed a message to that effect when editing).